### PR TITLE
Organize arr service modules into dedicated subpackages

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,16 @@ This MCP server allows AI assistants to query your movie and TV show collection 
 
 ## Project Structure
 
-Arr service wrappers live in the top-level `arrs/` package for clarity:
+Arr service wrappers now live in dedicated subfolders under the top-level `arrs/` package for clarity:
 
 ```
 arrs/
-  base.py        # shared HTTP helpers
-  radarr.py      # Radarr client and Movie model
-  sonarr.py      # Sonarr client and Series/Episode models
-  lidarr.py      # Lidarr client
-  whisparr.py    # Whisparr client
-  readarr.py     # Readarr client
+  base.py     # shared HTTP helpers
+  radarr/     # Radarr client and Movie model
+  sonarr/     # Sonarr client and Series/Episode models
+  lidarr/     # Lidarr client
+  whisparr/   # Whisparr client
+  readarr/    # Readarr client
 ```
 
 The MCP server and CLI remain under `radarr_sonarr_mcp/`.

--- a/arrs/lidarr/__init__.py
+++ b/arrs/lidarr/__init__.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any
 import requests
 
 from radarr_sonarr_mcp.config import LidarrConfig
-from .base import BaseArrService
+from ..base import BaseArrService
 
 
 @dataclass

--- a/arrs/radarr/__init__.py
+++ b/arrs/radarr/__init__.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any
 import requests
 
 from radarr_sonarr_mcp.config import RadarrConfig
-from .base import BaseArrService
+from ..base import BaseArrService
 
 
 @dataclass

--- a/arrs/readarr/__init__.py
+++ b/arrs/readarr/__init__.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any
 import requests
 
 from radarr_sonarr_mcp.config import ReadarrConfig
-from .base import BaseArrService
+from ..base import BaseArrService
 
 
 @dataclass

--- a/arrs/sonarr/__init__.py
+++ b/arrs/sonarr/__init__.py
@@ -5,7 +5,7 @@ from typing import List, Dict, Any, Optional
 import requests
 
 from radarr_sonarr_mcp.config import SonarrConfig
-from .base import BaseArrService
+from ..base import BaseArrService
 
 
 @dataclass

--- a/arrs/whisparr/__init__.py
+++ b/arrs/whisparr/__init__.py
@@ -4,8 +4,8 @@ from typing import List
 import requests
 
 from radarr_sonarr_mcp.config import WhisparrConfig
-from .base import BaseArrService
-from .radarr import Movie
+from ..base import BaseArrService
+from ..radarr import Movie
 
 
 class WhisparrService(BaseArrService):


### PR DESCRIPTION
## Summary
- organize individual Arr service wrappers into their own subfolders under the `arrs` package for clearer structure
- adjust imports to the new locations and update README to document the layout

## Testing
- `pip install -r requirements.txt`
- `pip install fastmcp`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_689c092eadf08322af4550211e2657de