### PR TITLE
Add cross-platform setup scripts and environment template

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,10 @@
+SONARR_URL=http://localhost:8989
+SONARR_API_KEY=your_sonarr_api_key
+RADARR_URL=http://localhost:7878
+RADARR_API_KEY=your_radarr_api_key
+WHISPARR_URL=http://localhost:6969
+WHISPARR_API_KEY=your_whisparr_api_key
+LIDARR_URL=http://localhost:8686
+LIDARR_API_KEY=your_lidarr_api_key
+READARR_URL=http://localhost:8787
+READARR_API_KEY=your_readarr_api_key

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ Example `config.json`:
 
 ### Setup scripts
 
-Collect keys automatically with the provided scripts:
+Bootstrap the project and collect service credentials with the provided scripts:
 
 ```bash
 # Linux
@@ -108,6 +108,13 @@ scripts/setup_linux.sh
 # Windows PowerShell
 scripts/setup_windows.ps1
 ```
+
+These scripts will:
+
+- Ensure Python 3 is available and create a virtual environment in `.venv`
+- Install dependencies from `requirements.txt`
+- Prompt for service host URLs and API keys
+- Write the values to a `.env` file and to `~/.yarr_config.json` with keys stored in your OS keyring
 
 You will be prompted for each service:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 mcp>=0.1.0
+fastmcp>=2.0.0
 requests>=2.28.0
 pydantic>=2.0.0
 pytest>=7.0.0

--- a/scripts/setup_linux.sh
+++ b/scripts/setup_linux.sh
@@ -1,18 +1,57 @@
 #!/usr/bin/env bash
-# Simple setup script for configuring arr service endpoints and API keys on Linux.
+# All-in-one setup script for configuring arr service endpoints, API keys, and Python environment on Linux.
 set -e
 
-read -p "Please enter your Sonarr Host URL: " SONARR_URL
-read -p "Please enter your Sonarr Api Key: " SONARR_KEY
-read -p "Please enter your Radarr Host URL: " RADARR_URL
-read -p "Please enter your Radarr Api Key: " RADARR_KEY
-read -p "Please enter your Whisparr Host URL: " WHISPARR_URL
-read -p "Please enter your Whisparr Api Key: " WHISPARR_KEY
-read -p "Please enter your Lidarr Host URL: " LIDARR_URL
-read -p "Please enter your Lidarr Api Key: " LIDARR_KEY
-read -p "Please enter your Readarr Host URL: " READARR_URL
-read -p "Please enter your Readarr Api Key: " READARR_KEY
+# Ensure Python 3 is installed
+if ! command -v python3 >/dev/null 2>&1; then
+  echo "python3 not found, attempting to install..."
+  if command -v apt-get >/dev/null 2>&1; then
+    sudo apt-get update
+    sudo apt-get install -y python3 python3-venv
+  else
+    echo "Please install Python 3 manually and re-run this script."
+    exit 1
+  fi
+fi
 
+# Create virtual environment if it doesn't exist
+if [ ! -d ".venv" ]; then
+  python3 -m venv .venv
+fi
+source .venv/bin/activate
+
+# Install Python dependencies
+pip install -r requirements.txt
+
+# Collect configuration details
+read -p "Please enter your Sonarr Host URL: " SONARR_URL
+read -p "Please enter your Sonarr API Key: " SONARR_KEY
+read -p "Please enter your Radarr Host URL: " RADARR_URL
+read -p "Please enter your Radarr API Key: " RADARR_KEY
+read -p "Please enter your Whisparr Host URL: " WHISPARR_URL
+read -p "Please enter your Whisparr API Key: " WHISPARR_KEY
+read -p "Please enter your Lidarr Host URL: " LIDARR_URL
+read -p "Please enter your Lidarr API Key: " LIDARR_KEY
+read -p "Please enter your Readarr Host URL: " READARR_URL
+read -p "Please enter your Readarr API Key: " READARR_KEY
+
+# Write .env file
+cat > .env <<ENV
+SONARR_URL=$SONARR_URL
+SONARR_API_KEY=$SONARR_KEY
+RADARR_URL=$RADARR_URL
+RADARR_API_KEY=$RADARR_KEY
+WHISPARR_URL=$WHISPARR_URL
+WHISPARR_API_KEY=$WHISPARR_KEY
+LIDARR_URL=$LIDARR_URL
+LIDARR_API_KEY=$LIDARR_KEY
+READARR_URL=$READARR_URL
+READARR_API_KEY=$READARR_KEY
+ENV
+
+echo ".env configuration written."
+
+# Persist configuration and API keys using keyring
 python3 - <<PY
 import json, os, keyring
 config_path = os.path.expanduser("~/.yarr_config.json")

--- a/scripts/setup_windows.ps1
+++ b/scripts/setup_windows.ps1
@@ -1,5 +1,26 @@
 param()
 
+# Ensure Python is installed
+if (-not (Get-Command python -ErrorAction SilentlyContinue)) {
+    Write-Output "Python not found. Attempting to install with winget..."
+    if (Get-Command winget -ErrorAction SilentlyContinue) {
+        winget install -e --id Python.Python.3
+    } else {
+        Write-Error "winget not found. Please install Python 3 manually and re-run this script."
+        exit 1
+    }
+}
+
+# Create virtual environment if missing
+if (-not (Test-Path ".venv")) {
+    python -m venv .venv
+}
+.\.venv\Scripts\Activate.ps1
+
+# Install Python dependencies
+pip install -r requirements.txt
+
+# Collect configuration details
 $sonarrUrl = Read-Host "Please enter your Sonarr Host URL"
 $sonarrKey = Read-Host "Please enter your Sonarr Api Key"
 $radarrUrl = Read-Host "Please enter your Radarr Host URL"
@@ -11,9 +32,25 @@ $lidarrKey = Read-Host "Please enter your Lidarr Api Key"
 $readarrUrl = Read-Host "Please enter your Readarr Host URL"
 $readarrKey = Read-Host "Please enter your Readarr Api Key"
 
+# Write .env file
+$envContent = @"
+SONARR_URL=$sonarrUrl
+SONARR_API_KEY=$sonarrKey
+RADARR_URL=$radarrUrl
+RADARR_API_KEY=$radarrKey
+WHISPARR_URL=$whisparrUrl
+WHISPARR_API_KEY=$whisparrKey
+LIDARR_URL=$lidarrUrl
+LIDARR_API_KEY=$lidarrKey
+READARR_URL=$readarrUrl
+READARR_API_KEY=$readarrKey
+"@
+Set-Content -Path ".env" -Value $envContent -Encoding UTF8
+Write-Output ".env configuration written."
+
 $py = @"
 import json, os, keyring
-config_path = os.path.join(os.path.expanduser('~'), 'yarr_config.json')
+config_path = os.path.join(os.path.expanduser('~'), '.yarr_config.json')
 try:
     with open(config_path, 'r', encoding='utf-8') as fh:
         data = json.load(fh)


### PR DESCRIPTION
## Summary
- extend Linux and Windows setup scripts to install Python deps, create virtual env, and prompt for service credentials
- add `.env.example` for hostname and API key configuration
- document setup workflow and add `fastmcp` dependency

## Testing
- `pip install -r requirements.txt`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_689c0c1e16908322920eb8d8a19aa76c