### PR TITLE
Add Servarr wiki reference documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,8 @@
 Yarr is a Python-based [Model Context Protocol](https://github.com/modelcontextprotocol) server that gives AI assistants like Claude natural-language access to your Radarr (movies) and Sonarr (TV series) libraries.
 Lightweight clients for the rest of the `arr` ecosystem – Lidarr, Whisparr and Readarr – are included so you can extend the same tooling to music, adult content and ebooks.
 
+For additional details on installing and configuring these services, consult the [Servarr Wiki Reference](docs/servarr_wiki_reference.md).
+
 ## Architecture
 
 ```mermaid

--- a/docs/servarr_wiki_reference.md
+++ b/docs/servarr_wiki_reference.md
@@ -1,0 +1,8 @@
+# Servarr Wiki Reference
+
+This project integrates with the Servarr ecosystem, including Radarr and Sonarr. For comprehensive guidance on installing and configuring these services, consult the official Servarr Wiki.
+
+- [Radarr Wiki](https://github.com/Servarr/Wiki/wiki/Radarr)
+- [Sonarr Wiki](https://github.com/Servarr/Wiki/wiki/Sonarr)
+
+The wiki covers topics such as installation, API key location, and networking considerations. Refer to the "Settings" sections in each wiki for instructions on locating the API key used by Yarr.


### PR DESCRIPTION
## Summary
- document Servarr wiki as a resource for Radarr and Sonarr setup
- link README to the new wiki reference

## Testing
- `python run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_689c1188dbbc8322a865cb744e0df976