### PR TITLE
Allow configuring server port via environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,8 +118,9 @@ values in `~/.yarr_config.json`.
 radarr-sonarr-mcp start
 ```
 
-By default the server listens on port `3000`. Add `http://localhost:3000` as an
-MCP server in your client (e.g. Claude Desktop).
+By default the server listens on the port defined by the `MCP_SERVER_PORT`
+environment variable (default `3333`). Add `http://localhost:3333` as an MCP
+server in your client (e.g. Claude Desktop).
 
 For quick local iteration you can run the server directly:
 

--- a/config.json.example
+++ b/config.json.example
@@ -12,7 +12,7 @@
         "SONARR_PORT": "8989",
         "RADARR_API_KEY": "x",
         "SONARR_API_KEY": "x",
-        "MCP_SERVER_PORT": "3000",
+        "MCP_SERVER_PORT": "3333",
         "JELLYFIN_BASE_URL": "http://10.0.0.23:5055",
         "JELLYFIN_API_KEY": "your_jellyfin_api_key",
         "JELLYFIN_USER_ID": "your_jellyfin_user_id",

--- a/radarr_sonarr_mcp/cli.py
+++ b/radarr_sonarr_mcp/cli.py
@@ -2,6 +2,7 @@
 
 import argparse
 import logging
+import os
 
 from .config import Config, NasConfig, RadarrConfig, SonarrConfig, ServerConfig, load_config, save_config
 from .server import create_server
@@ -55,15 +56,16 @@ def configure():
     )
     
     # Server configuration
-    server_port = input(f"MCP server port [{config.server_config.port if config else '3000'}]: ")
+    default_port = config.server_config.port if config else int(os.getenv("MCP_SERVER_PORT", "3333"))
+    server_port = input(f"MCP server port [{default_port}]: ")
     if server_port:
         try:
             server_port = int(server_port)
         except ValueError:
             logging.warning("Invalid port number, using default.")
-            server_port = config.server_config.port if config else 3000
+            server_port = default_port
     else:
-        server_port = config.server_config.port if config else 3000
+        server_port = default_port
     
     # Create new config
     new_config = Config(

--- a/radarr_sonarr_mcp/config.py
+++ b/radarr_sonarr_mcp/config.py
@@ -5,6 +5,7 @@ from dataclasses import dataclass, asdict, field
 from pathlib import Path
 from typing import Optional
 import json
+import os
 
 try:
     import keyring  # type: ignore
@@ -55,7 +56,7 @@ class NasConfig:
 
 @dataclass
 class ServerConfig:
-    port: int = 3000
+    port: int = field(default_factory=lambda: int(os.getenv("MCP_SERVER_PORT", "3333")))
 
 
 @dataclass
@@ -113,6 +114,9 @@ def load_config(path: Optional[str] = None) -> Config:
         readarr_config=_svc(ReadarrConfig, data.get("readarrConfig", {}), "8787"),
         server_config=ServerConfig(**data.get("server", {})),
     )
+
+    # Allow environment variable to override configured port
+    cfg.server_config.port = int(os.getenv("MCP_SERVER_PORT", cfg.server_config.port))
 
     _apply_keyring(cfg.radarr_config, "radarr")
     _apply_keyring(cfg.sonarr_config, "sonarr")


### PR DESCRIPTION
## Summary
- Allow overriding server port with the `MCP_SERVER_PORT` environment variable
- Adjust CLI and sample config to reference `MCP_SERVER_PORT` and default to 3333
- Update docs to explain configurable port

## Testing
- `python run_tests.py`


------
https://chatgpt.com/codex/tasks/task_e_689c2cf94e9c8322b6f247a4ddf8c8f1